### PR TITLE
Benchmark: Random Nonce

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile project(":validation")
     compile project(":runtime")
 
+    compile "it.unimi.dsi:dsiutils:$dsiUtilVersion"
 
     jmh 'org.openjdk.jmh:jmh-core:1.21'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.21'

--- a/benchmarks/src/jmh/java/io/micronaut/context/env/RandomNonceBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/context/env/RandomNonceBenchmark.java
@@ -1,0 +1,108 @@
+package io.micronaut.context.env;
+
+
+import it.unimi.dsi.Util;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+
+
+@State(Scope.Benchmark)
+public class RandomNonceBenchmark {
+  /**
+   * Length of generated CSP nonce values. Must be a multiple of 8.
+   */
+  public static final int NONCE_LENGTH = 8 * 2;
+
+  private static final Random defaultRandom;
+  private static final Random sha1Random;
+  private static final Random nativeRandom;
+  private static final Random secureRandom;
+
+  public enum StaticAlgorithm {
+    XOROSHIRO_128,
+    XORSHIFT_2014;
+
+    public byte[] generateBytes() {
+      switch (this) {
+        case XOROSHIRO_128:
+          byte[] randomBytes = new byte[NONCE_LENGTH];
+          int iter = 0;
+          while (iter < (NONCE_LENGTH / 8)) {
+            System.arraycopy(Util.randomSeedBytes(), 0, randomBytes, iter * 8, 8);
+            iter++;
+          }
+          return randomBytes;
+      }
+      throw new IllegalStateException(
+        "Static algorithm not implemented: " + this.name());
+    }
+  }
+
+  static {
+    try {
+      defaultRandom = new Random();
+      secureRandom = SecureRandom.getInstanceStrong();
+      sha1Random = SecureRandom.getInstance("SHA1PRNG");
+      nativeRandom = SecureRandom.getInstance("NativePRNG");
+    } catch (NoSuchAlgorithmException nsae) {
+      throw new RuntimeException(nsae);
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .include(".*" + RandomNonceBenchmark.class.getSimpleName() + ".*")
+      .warmupIterations(3)
+      .measurementIterations(5)
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+
+  // Generate a CSP nonce with the provided random tool.
+  private byte[] generateCSPNonce(Random random) {
+    byte[] randomBytes = new byte[NONCE_LENGTH];
+    random.nextBytes(randomBytes);
+    return randomBytes;
+  }
+
+  // Generate a CSP nonce with the provided random tool, or if `null`, static utils.
+  private byte[] generateCSPNonce(StaticAlgorithm algo) {
+    return algo.generateBytes();
+  }
+
+  @Benchmark
+  public void benchmarkDefaultRandom() {
+    generateCSPNonce(defaultRandom);
+  }
+
+  @Benchmark
+  public void benchmarkSHA1Random() {
+    generateCSPNonce(sha1Random);
+  }
+
+  @Benchmark
+  public void benchmarkNativeRandom() {
+    generateCSPNonce(nativeRandom);
+  }
+
+  @Benchmark
+  public void benchmarkSecureRandom() {
+    generateCSPNonce(secureRandom);
+  }
+
+  @Benchmark
+  public void benchmarkXoroshiro128() {
+    generateCSPNonce(StaticAlgorithm.XOROSHIRO_128);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -116,3 +116,4 @@ hibernateVersion=5.4.3.Final
 methvinDirectoryWatcherVersion=0.9.6
 jnaVersion=5.3.1
 elasticsearchVersion=6.4.0
+dsiUtilVersion=2.6.0


### PR DESCRIPTION
DRAFT:

This benchmark tests random nonce generation. It was much easier to add it here than in `micronaut-views`. It tests `Random`, vs. `SecureRandom`, vs. some other exotic algorithms.

I've used it for implementing CSP nonce support over in my PR at micronaut-projects/micronaut-views#14 (and, also, downstream in that repo at micronaut-projects/micronaut-views#16).

I will comment with results on macOS and Linux.